### PR TITLE
Add necessary improvements.

### DIFF
--- a/lib/pseudo_model.rb
+++ b/lib/pseudo_model.rb
@@ -3,6 +3,7 @@ require "pseudo_model/version"
 module PseudoModel
   class Base
     include ActiveModel::Validations
+    include ActiveModel::Validations::Callbacks
     include ActiveModel::Conversion
 
     def initialize(attributes = {})

--- a/lib/pseudo_model.rb
+++ b/lib/pseudo_model.rb
@@ -6,6 +6,9 @@ module PseudoModel
     include ActiveModel::Conversion
 
     def initialize(attributes = {})
+      raise TypeError, '`attributes` must be a Hash or respond to :to_hash or :to_h' unless attributes.is_a?(Hash) || attributes.respond_to?(:to_hash) || attributes.respond_to?(:to_h)
+      attributes = attributes.to_hash rescue attributes.to_h unless attributes.is_a?(Hash)
+      
       attributes.each do |name, value|
         send("#{name}=", value)
       end

--- a/lib/pseudo_model.rb
+++ b/lib/pseudo_model.rb
@@ -1,4 +1,5 @@
-require "pseudo_model/version"
+require 'pseudo_model/version'
+require 'active_model'
 
 module PseudoModel
   class Base

--- a/pseudo_model.gemspec
+++ b/pseudo_model.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
+  
+  gem.add_dependency 'activemodel', '~> 3.2'
 end


### PR DESCRIPTION
- **Require `active_model`.**  
  Without ActiveModel required, users would have to call `require 'active_model'` manually before being able to use `pseudo_model`.
- **Add the `activemodel` gem as a dependency in the gemspec.**  
  Without ActiveModel set as a dependency, users would have to run `gem install activemodel` manually before being able to use `pseudo_model`.
- **Add validation and conversion of the `attributes` argument for `PseudoModel::Base#initialize`.**  
  This way, if a Hash or a Hash-like object gets passed to `initialize` then everything will work okay. Otherwise, a TypeError will be raised.
- **Add `ActiveModel::Validations::Callbacks`.**  
  This adds the `before_validation`, `around_validation`, and `after_validation` methods.
